### PR TITLE
Changing the wait after a deploy to 60 seconds.

### DIFF
--- a/Server_Side/admin/demo/CRUD/create.js
+++ b/Server_Side/admin/demo/CRUD/create.js
@@ -240,7 +240,7 @@ function deploy_vehicle(req, res)
 		if (!error && response.statusCode == 200) 
 		{
 			counter = 0;
-			setTimeout(function(){create_cars(req, res);},30000)
+			setTimeout(function(){create_cars(req, res);},60000)
 
 		}
 		else

--- a/Server_Side/blockchain/chaincode/vehicle_logs/CRUD/create.js
+++ b/Server_Side/blockchain/chaincode/vehicle_logs/CRUD/create.js
@@ -45,7 +45,7 @@ function deploy(req, res)
 			console.log("VEHICLE LOG DEPLOY NAME",body.result.message)
 			setTimeout(function() {
 				update_config(body.result.message, res)
-			}, 5000);
+			}, 60000);
 		}
 		else
 		{

--- a/Server_Side/blockchain/chaincode/vehicles/CRUD/create.js
+++ b/Server_Side/blockchain/chaincode/vehicles/CRUD/create.js
@@ -45,7 +45,7 @@ function deploy(req, res)
 			console.log("VEHICLE DEPLOY NAME",body.result.message)
 			setTimeout(function() {
 				update_config(body.result.message, res)
-			}, 5000);
+			}, 60000);
 		}
 		else
 		{


### PR DESCRIPTION
We need to wait for enough time period so that the chaincode image can be built (chaincode can be compiled) and the container can be started by the peer.