### PR TITLE
Correct formatting for displaying on github.com

### DIFF
--- a/Documentation/Installation Guide.md
+++ b/Documentation/Installation Guide.md
@@ -4,27 +4,27 @@ Installation Guide
 To deploy to Bluemix simply use the button below then follow the instructions. This will generate the NodeJS server and the Blockchain service for you.
 
 [![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM-Blockchain/car-lease-demo.git)
-##Deploying Locally##
+## Deploying Locally ##
 
-###Prerequisites###
+### Prerequisites ###
 To deploy locally you will need to have installed:
 
  - [NodeJS v6.x](https://nodejs.org/en/download/)
  - [npm](https://docs.npmjs.com/getting-started/installing-node)
  - [Git](https://git-scm.com/download)
- - [Docker] (https://docs.docker.com/engine/installation/linux/ubuntulinux/)
+ - [Docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/)
 
-###Cloning the repository###
+### Cloning the repository ###
 Open up a terminal or command window where you wish to have the app then run:
 
     git clone https://github.com/IBM-Blockchain/car-lease-demo.git
 
-###Installing npm required modules###
+### Installing npm required modules ###
 The application makes use of a number of modules developed externally that must be installed to run. To do this open a terminal or command window in the car-lease-demo folder and run the command:
 
     npm install
 
-###Updating the configurations file###
+### Updating the configurations file ###
 
 When deploying locally the following settings need to be changed in the configuration.js file:
 
@@ -34,15 +34,15 @@ When deploying locally the following settings need to be changed in the configur
 
 `config.hfcProtocol = 'grpc';`
 
-More information on the configuration file can be found in [Server Side.md](/Documentation/Server Side.md)
+More information on the configuration file can be found in [Server Side.md](./Server%20Side.md)
 
-####Connecting to a non-default NodeJS server####
+#### Connecting to a non-default NodeJS server ####
 
 The NodeJS server by default runs on localhost:8080. If you are running in a different location then in `Server_Side/configurations/configuration.js`
 change the `app_url` variable to be the url of where the app server should run including the port. You will also need to change `appPort` to be the port
 for the NodeJS server.
 
-####Connecting to a non-default setup local peer####
+#### Connecting to a non-default setup local peer ####
 The configurations file by default is set up to use a local peer set up using the HyperLedger fabric default settings e.g. IP of 127.0.0.1, api_port:7050 and discovery_port:7051.
 If your local peer uses different settings then the following will need to be changed in `credentials.json` under 'peer':
 
@@ -61,13 +61,13 @@ If your local member service uses different settings then the following will als
 A backup of credential required for local deployment can be found in `local-credentials.json`
 
 
-####Connecting to an external Bluemix Peer####
+#### Connecting to an external Bluemix Peer ####
 To connect to an external Bluemix peer, copy the services VCAP variables into `credentials.json`
 These VCAP variables can be found in a Bluemix service under 'Service Credentials' as shown below.
 
-![Copy VCAP](/Images/VCAP Creds.png)
+![Copy VCAP](../Images/VCAP%20Creds.png)
 
-###Running the application###
+### Running the application ###
 To start the application, change your current working directory to `Scripts`. Then run the `start.sh` script in a terminal or command prompt window using:
 
     ./start.sh
@@ -75,7 +75,7 @@ To start the application, change your current working directory to `Scripts`. Th
 
 You can then view it by opening your browser to where you have NodeJS running. By default it will load on http://localhost:8080.
 
-###Retrieving Logs###
+### Retrieving Logs ###
 Assuming you're running locally, peer logs can be retrieved from Docker containers.
 Once the start.sh script has finished running the following commands can be ran from within a terminal:
 
@@ -86,9 +86,9 @@ Once the start.sh script has finished running the following commands can be ran 
        - Peer container
        - Membersrvc container
 
-![Docker ps](/Images/DockerPs.png)
+![Docker ps](../Images/DockerPs.png)
 
 `docker logs -f DOCKER_ID` (This will show all logging where DOCKER_ID is replaced with a Docker container ID)
 *Note: To find the full Docker container ID, start to type the container ID then press 'TAB' to autocomplete in the terminal
 
-![Docker logs](/Images/DockerLogs.png)
+![Docker logs](../Images/DockerLogs.png)


### PR DESCRIPTION
Corrected a few typo's which caused the Installation Guide to look unformatted on github.com.
![screen shot 2017-03-27 at 11 11 11](https://cloud.githubusercontent.com/assets/803296/24349043/1eba6f56-12de-11e7-9af6-c6acda12ee7c.png)
vs
![screen shot 2017-03-27 at 11 15 19](https://cloud.githubusercontent.com/assets/803296/24349256/b23e08dc-12de-11e7-8cc1-c0a323a33e57.png)
